### PR TITLE
feat: add customer account hub and mobile UX

### DIFF
--- a/client/src/api/customerAccount.ts
+++ b/client/src/api/customerAccount.ts
@@ -1,0 +1,144 @@
+import axios from "./axios";
+
+export type CustomerIdentity = {
+    id: string;
+    email: string;
+    username: string;
+    first_name: string | null;
+    last_name: string | null;
+    role: string;
+    created_at: string;
+    last_login: string;
+};
+
+export type CustomerOrder = {
+    id: number;
+    date_added: string;
+    status: number;
+    total_price: number;
+    discount: number;
+    shipping_address: string;
+    payment_method?: "bank_transfer" | "cash";
+};
+
+export type CustomerOrderItem = {
+    productId: number;
+    productName: string;
+    brand: string;
+    category: string;
+    price: number;
+    sale_price: number | null;
+    stock: number;
+    quantity: number;
+    totalPrice: number;
+};
+
+export type CustomerOrderTimelineEvent = {
+    id: number;
+    label: string;
+    note: string | null;
+    created_at: string | null;
+    status: number;
+};
+
+export type CustomerOrderDetail = CustomerOrder & {
+    items: CustomerOrderItem[];
+    timeline?: CustomerOrderTimelineEvent[];
+};
+
+export type CustomerAddress = {
+    id: number;
+    label: string;
+    recipient_name: string | null;
+    phone_number: string | null;
+    address_line: string;
+    city: string | null;
+    country: string | null;
+    is_default: boolean;
+};
+
+export type CustomerAddressPayload = {
+    label: string;
+    recipientName: string;
+    phoneNumber: string;
+    addressLine: string;
+    city: string;
+    country: string;
+    isDefault: boolean;
+};
+
+export type CustomerNotification = {
+    id: number;
+    type: string;
+    title: string;
+    message: string;
+    link: string | null;
+    read_at: string | null;
+    created_at: string;
+    is_read: boolean;
+};
+
+export async function fetchCurrentCustomer(): Promise<CustomerIdentity | null> {
+    const response = await axios.get("/api/users/me", { withCredentials: true });
+    return response.data.userData || null;
+}
+
+export async function fetchCustomerOrders(uid: string): Promise<CustomerOrder[]> {
+    const response = await axios.get(`/api/orders/user/${uid}`);
+    return response.data.orders || [];
+}
+
+export async function fetchCustomerOrderDetail(orderId: number): Promise<CustomerOrderDetail | null> {
+    const response = await axios.get(`/api/orders/${orderId}`);
+    return response.data.order || null;
+}
+
+export async function addItemsToCustomerCart(
+    uid: string,
+    items: Array<{ productId: number; quantity: number; stock: number }>
+): Promise<void> {
+    await Promise.all(
+        items.map((item) =>
+            axios.post("/api/cart/", {
+                uid,
+                pid: item.productId,
+                quantity: Math.min(item.quantity, item.stock),
+            })
+        )
+    );
+}
+
+export async function fetchCustomerAddresses(uid: string): Promise<CustomerAddress[]> {
+    const response = await axios.get(`/api/users/${uid}/addresses`);
+    return response.data.addresses || [];
+}
+
+export async function createCustomerAddress(uid: string, payload: CustomerAddressPayload): Promise<CustomerAddress> {
+    const response = await axios.post(`/api/users/${uid}/addresses`, payload);
+    return response.data.address;
+}
+
+export async function updateCustomerAddress(
+    uid: string,
+    addressId: number,
+    payload: CustomerAddressPayload
+): Promise<CustomerAddress> {
+    const response = await axios.put(`/api/users/${uid}/addresses/${addressId}`, payload);
+    return response.data.address;
+}
+
+export async function deleteCustomerAddress(uid: string, addressId: number): Promise<void> {
+    await axios.delete(`/api/users/${uid}/addresses/${addressId}`);
+}
+
+export async function fetchCustomerNotifications(uid: string, limit = 50): Promise<{ notifications: CustomerNotification[]; unread: number }> {
+    const response = await axios.get(`/api/users/${uid}/notifications?limit=${limit}`);
+    return {
+        notifications: response.data.notifications || [],
+        unread: Number(response.data.unread) || 0,
+    };
+}
+
+export async function markAllCustomerNotificationsRead(uid: string): Promise<void> {
+    await axios.post(`/api/users/${uid}/notifications/read-all`);
+}

--- a/client/src/components/common/account/CustomerAccountShell.tsx
+++ b/client/src/components/common/account/CustomerAccountShell.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { Link, useLocation } from "react-router-dom";
+import { BellIcon, CartIcon, HouseIcon, PersonIcon } from "../Icons";
+import "../../../styles/CustomerAccountShell.scss";
+
+type CustomerAccountShellProps = {
+    eyebrow: string;
+    title: string;
+    description: string;
+    actions?: React.ReactNode;
+};
+
+const navItems = [
+    { to: "/account", label: "Account", icon: <PersonIcon size={16} /> },
+    { to: "/orders", label: "Orders", icon: <CartIcon size={16} /> },
+    { to: "/addresses", label: "Addresses", icon: <HouseIcon size={16} /> },
+    { to: "/notifications", label: "Notifications", icon: <BellIcon size={16} /> },
+];
+
+const CustomerAccountShell = ({ eyebrow, title, description, actions }: CustomerAccountShellProps) => {
+    const location = useLocation();
+
+    return (
+        <section className="customer-account-shell">
+            <div className="customer-account-shell__header">
+                <div>
+                    <span>{eyebrow}</span>
+                    <h1>{title}</h1>
+                    <p>{description}</p>
+                </div>
+                {actions ? <div className="customer-account-shell__actions">{actions}</div> : null}
+            </div>
+
+            <nav className="customer-account-shell__nav" aria-label="Customer account navigation">
+                {navItems.map((item) => (
+                    <Link key={item.to} to={item.to} className={location.pathname === item.to ? "is-active" : ""}>
+                        {item.icon}
+                        <span>{item.label}</span>
+                    </Link>
+                ))}
+            </nav>
+        </section>
+    );
+};
+
+export default CustomerAccountShell;

--- a/client/src/components/layout/Header.tsx
+++ b/client/src/components/layout/Header.tsx
@@ -12,6 +12,7 @@ import { useAuth } from "../../context/AuthContext";
 import "../../styles/Header.scss";
 import { useToast } from "../../context/ToastContext";
 import axios from "../../api/axios";
+import { fetchCustomerNotifications } from "../../api/customerAccount";
 import { signOut } from "firebase/auth";
 import { auth } from "../../services/firebase";
 import { Product } from "../../utils/interface";
@@ -127,8 +128,8 @@ export const Header = (): JSX.Element => {
             }
 
             try {
-                const response = await axios.get(`/api/users/${userData.id}/notifications?limit=10`);
-                setUnreadNotifications(Number(response.data.unread) || 0);
+                const response = await fetchCustomerNotifications(userData.id, 10);
+                setUnreadNotifications(response.unread);
             } catch {
                 setUnreadNotifications(0);
             }

--- a/client/src/components/pages/AddressBookPage.tsx
+++ b/client/src/components/pages/AddressBookPage.tsx
@@ -1,21 +1,18 @@
 import React, { useEffect, useState } from "react";
 import { Helmet } from "react-helmet";
-import axios from "../../api/axios";
+import {
+    CustomerAddress,
+    CustomerAddressPayload,
+    createCustomerAddress,
+    deleteCustomerAddress,
+    fetchCustomerAddresses,
+    updateCustomerAddress,
+} from "../../api/customerAccount";
 import { useAuth } from "../../context/AuthContext";
 import { useToast } from "../../context/ToastContext";
+import CustomerAccountShell from "../common/account/CustomerAccountShell";
 import Layout from "../layout/Layout";
 import "../../styles/AddressBookPage.scss";
-
-type Address = {
-    id: number;
-    label: string;
-    recipient_name: string | null;
-    phone_number: string | null;
-    address_line: string;
-    city: string | null;
-    country: string | null;
-    is_default: boolean;
-};
 
 type AddressForm = {
     id?: number;
@@ -42,15 +39,14 @@ const AddressBookPage = () => {
     const { userData } = useAuth();
     const uid = userData?.id || "";
     const { addToast } = useToast();
-    const [addresses, setAddresses] = useState<Address[]>([]);
+    const [addresses, setAddresses] = useState<CustomerAddress[]>([]);
     const [form, setForm] = useState<AddressForm>(emptyForm);
     const [isSaving, setIsSaving] = useState(false);
 
     const fetchAddresses = async () => {
         if (!uid) return;
         try {
-            const response = await axios.get(`/api/users/${uid}/addresses`);
-            setAddresses(response.data.addresses || []);
+            setAddresses(await fetchCustomerAddresses(uid));
         } catch {
             addToast("Address book", "Unable to load saved addresses.");
         }
@@ -60,7 +56,7 @@ const AddressBookPage = () => {
         fetchAddresses();
     }, [uid]);
 
-    const handleEdit = (address: Address) => {
+    const handleEdit = (address: CustomerAddress) => {
         setForm({
             id: address.id,
             label: address.label || "Shipping address",
@@ -82,7 +78,7 @@ const AddressBookPage = () => {
 
         try {
             setIsSaving(true);
-            const payload = {
+            const payload: CustomerAddressPayload = {
                 label: form.label,
                 recipientName: form.recipientName,
                 phoneNumber: form.phoneNumber,
@@ -92,10 +88,10 @@ const AddressBookPage = () => {
                 isDefault: form.isDefault,
             };
             if (form.id) {
-                await axios.put(`/api/users/${uid}/addresses/${form.id}`, payload);
+                await updateCustomerAddress(uid, form.id, payload);
                 addToast("Address book", "Address updated.");
             } else {
-                await axios.post(`/api/users/${uid}/addresses`, payload);
+                await createCustomerAddress(uid, payload);
                 addToast("Address book", "Address saved.");
             }
             setForm(emptyForm);
@@ -110,7 +106,7 @@ const AddressBookPage = () => {
     const handleDelete = async (addressId: number) => {
         if (!uid) return;
         try {
-            await axios.delete(`/api/users/${uid}/addresses/${addressId}`);
+            await deleteCustomerAddress(uid, addressId);
             addToast("Address book", "Address removed.");
             fetchAddresses();
         } catch {
@@ -125,11 +121,11 @@ const AddressBookPage = () => {
                 <meta name="description" content="Manage saved shipping addresses." />
             </Helmet>
             <main className="address-book">
-                <header className="address-book__header">
-                    <span>Account</span>
-                    <h1>Address book</h1>
-                    <p>Save delivery addresses and select a default address for faster checkout.</p>
-                </header>
+                <CustomerAccountShell
+                    eyebrow="Account"
+                    title="Address book"
+                    description="Save delivery addresses and select a default address for faster checkout."
+                />
 
                 <section className="address-book__layout">
                     <div className="address-book__form">

--- a/client/src/components/pages/CheckoutPaymentPage.tsx
+++ b/client/src/components/pages/CheckoutPaymentPage.tsx
@@ -1,6 +1,7 @@
 import { Form } from "react-bootstrap";
 import { useNavigate } from "react-router-dom";
 import axios from "../../api/axios";
+import { CustomerAddress, fetchCustomerAddresses } from "../../api/customerAccount";
 import React, { useEffect, useMemo, useState } from "react";
 import { useAuth } from "../../context/AuthContext";
 import { Helmet } from "react-helmet";
@@ -40,16 +41,7 @@ type CheckoutPaymentProps = {
     subtotal: number;
 };
 
-type SavedAddress = {
-    id: number;
-    label: string;
-    recipient_name: string | null;
-    phone_number: string | null;
-    address_line: string;
-    city: string | null;
-    country: string | null;
-    is_default: boolean;
-};
+type SavedAddress = CustomerAddress;
 
 const CheckoutPaymentPage = ({ setIsPayment, cart, totalPrice, discount, subtotal }: CheckoutPaymentProps) => {
     const navigate = useNavigate();
@@ -96,8 +88,7 @@ const CheckoutPaymentPage = ({ setIsPayment, cart, totalPrice, discount, subtota
         const fetchAddresses = async () => {
             if (!uid) return;
             try {
-                const response = await axios.get(`/api/users/${uid}/addresses`);
-                setSavedAddresses(response.data.addresses || []);
+                setSavedAddresses(await fetchCustomerAddresses(uid));
             } catch {
                 setSavedAddresses([]);
             }

--- a/client/src/components/pages/CustomerAccountPage.tsx
+++ b/client/src/components/pages/CustomerAccountPage.tsx
@@ -1,0 +1,217 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { Helmet } from "react-helmet";
+import { Link } from "react-router-dom";
+import {
+    CustomerAddress,
+    CustomerIdentity,
+    CustomerNotification,
+    CustomerOrder,
+    fetchCurrentCustomer,
+    fetchCustomerAddresses,
+    fetchCustomerNotifications,
+    fetchCustomerOrders,
+} from "../../api/customerAccount";
+import { useAuth } from "../../context/AuthContext";
+import { useToast } from "../../context/ToastContext";
+import { BellIcon, CartIcon, HouseIcon, PersonIcon } from "../common/Icons";
+import CustomerAccountShell from "../common/account/CustomerAccountShell";
+import Layout from "../layout/Layout";
+import { formatUtcDate, formatUtcDateTime } from "../../utils/dateTime";
+import "../../styles/CustomerAccountPage.scss";
+
+const formatCurrency = (value: number) => `$${Number(value || 0).toFixed(2)}`;
+
+const getDisplayName = (customer: CustomerIdentity | null) => {
+    if (!customer) return "Customer";
+    const fullName = [customer.first_name, customer.last_name].filter(Boolean).join(" ").trim();
+    return fullName || customer.username || "Customer";
+};
+
+const getStatusLabel = (status: number) => {
+    if (status === 1) return "Done";
+    if (status === 0) return "Pending";
+    return "Canceled";
+};
+
+const CustomerAccountPage = () => {
+    const { userData } = useAuth();
+    const uid = userData?.id || "";
+    const { addToast } = useToast();
+    const [customer, setCustomer] = useState<CustomerIdentity | null>(null);
+    const [orders, setOrders] = useState<CustomerOrder[]>([]);
+    const [addresses, setAddresses] = useState<CustomerAddress[]>([]);
+    const [notifications, setNotifications] = useState<CustomerNotification[]>([]);
+    const [unreadNotifications, setUnreadNotifications] = useState(0);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        const loadAccount = async () => {
+            if (!uid) return;
+
+            try {
+                setLoading(true);
+                const [currentCustomer, customerOrders, customerAddresses, customerNotifications] = await Promise.all([
+                    fetchCurrentCustomer(),
+                    fetchCustomerOrders(uid),
+                    fetchCustomerAddresses(uid),
+                    fetchCustomerNotifications(uid, 6),
+                ]);
+
+                setCustomer(currentCustomer);
+                setOrders(customerOrders);
+                setAddresses(customerAddresses);
+                setNotifications(customerNotifications.notifications);
+                setUnreadNotifications(customerNotifications.unread);
+            } catch {
+                addToast("Account", "Unable to load your account overview.");
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        loadAccount();
+    }, [addToast, uid]);
+
+    const recentOrders = useMemo(() => orders.slice(0, 3), [orders]);
+    const primaryAddress = useMemo(
+        () => addresses.find((address) => address.is_default) || addresses[0] || null,
+        [addresses]
+    );
+    const recentNotifications = useMemo(() => notifications.slice(0, 3), [notifications]);
+
+    return (
+        <Layout>
+            <Helmet>
+                <title>My Account | Digital-E</title>
+                <meta name="description" content="Review your account, orders, saved addresses, and notifications." />
+            </Helmet>
+            <main className="customer-account-page">
+                <CustomerAccountShell
+                    eyebrow="Account"
+                    title="My account"
+                    description="Review your recent orders, saved addresses, and account activity from one place."
+                />
+
+                {loading ? (
+                    <section className="customer-account-page__loading">Loading your account...</section>
+                ) : (
+                    <>
+                        <section className="customer-account-page__hero">
+                            <div className="customer-account-page__identity">
+                                <span className="customer-account-page__identity__badge">
+                                    <PersonIcon size={16} />
+                                    Customer account
+                                </span>
+                                <h2>{getDisplayName(customer)}</h2>
+                                <p>{customer?.email || userData?.email || "No email available"}</p>
+                                <small>
+                                    Last active {customer?.last_login ? formatUtcDateTime(customer.last_login) : "recently"}
+                                </small>
+                            </div>
+
+                            <div className="customer-account-page__stats">
+                                <article>
+                                    <span>Orders</span>
+                                    <strong>{orders.length}</strong>
+                                </article>
+                                <article>
+                                    <span>Addresses</span>
+                                    <strong>{addresses.length}</strong>
+                                </article>
+                                <article>
+                                    <span>Unread alerts</span>
+                                    <strong>{unreadNotifications}</strong>
+                                </article>
+                            </div>
+                        </section>
+
+                        <section className="customer-account-page__actions">
+                            <Link to="/orders">
+                                <CartIcon size={18} />
+                                Order history
+                            </Link>
+                            <Link to="/addresses">
+                                <HouseIcon size={18} />
+                                Address book
+                            </Link>
+                            <Link to="/notifications">
+                                <BellIcon size={18} />
+                                Notifications
+                            </Link>
+                        </section>
+
+                        <section className="customer-account-page__grid">
+                            <article className="customer-account-page__panel">
+                                <div className="customer-account-page__panel__header">
+                                    <h3>Recent orders</h3>
+                                    <Link to="/orders">View all</Link>
+                                </div>
+                                {recentOrders.length > 0 ? (
+                                    <div className="customer-account-page__order-list">
+                                        {recentOrders.map((order) => (
+                                            <Link key={order.id} to={`/orders?order=${order.id}`}>
+                                                <div>
+                                                    <strong>Order #{order.id}</strong>
+                                                    <span>{formatUtcDate(order.date_added)}</span>
+                                                </div>
+                                                <div>
+                                                    <em>{getStatusLabel(order.status)}</em>
+                                                    <small>{formatCurrency(Math.max(order.total_price - order.discount, 0))}</small>
+                                                </div>
+                                            </Link>
+                                        ))}
+                                    </div>
+                                ) : (
+                                    <p className="customer-account-page__empty">No orders yet.</p>
+                                )}
+                            </article>
+
+                            <article className="customer-account-page__panel">
+                                <div className="customer-account-page__panel__header">
+                                    <h3>Saved address</h3>
+                                    <Link to="/addresses">Manage</Link>
+                                </div>
+                                {primaryAddress ? (
+                                    <div className="customer-account-page__address">
+                                        <strong>{primaryAddress.label}</strong>
+                                        <p>{primaryAddress.address_line}</p>
+                                        <span>
+                                            {[primaryAddress.city, primaryAddress.country].filter(Boolean).join(", ") || "Location not specified"}
+                                        </span>
+                                        <small>
+                                            {[primaryAddress.recipient_name, primaryAddress.phone_number].filter(Boolean).join(" | ") || "No recipient details"}
+                                        </small>
+                                    </div>
+                                ) : (
+                                    <p className="customer-account-page__empty">No saved addresses yet.</p>
+                                )}
+                            </article>
+
+                            <article className="customer-account-page__panel">
+                                <div className="customer-account-page__panel__header">
+                                    <h3>Recent notifications</h3>
+                                    <Link to="/notifications">Open</Link>
+                                </div>
+                                {recentNotifications.length > 0 ? (
+                                    <div className="customer-account-page__notification-list">
+                                        {recentNotifications.map((notification) => (
+                                            <Link key={notification.id} to={notification.link || "/notifications"} className={notification.is_read ? "" : "is-unread"}>
+                                                <strong>{notification.title}</strong>
+                                                <span>{formatUtcDateTime(notification.created_at)}</span>
+                                                <p>{notification.message}</p>
+                                            </Link>
+                                        ))}
+                                    </div>
+                                ) : (
+                                    <p className="customer-account-page__empty">No notifications yet.</p>
+                                )}
+                            </article>
+                        </section>
+                    </>
+                )}
+            </main>
+        </Layout>
+    );
+};
+
+export default CustomerAccountPage;

--- a/client/src/components/pages/CustomerNotificationsPage.tsx
+++ b/client/src/components/pages/CustomerNotificationsPage.tsx
@@ -1,23 +1,17 @@
 import React, { useEffect, useState } from "react";
 import { Helmet } from "react-helmet";
 import { Link } from "react-router-dom";
-import axios from "../../api/axios";
+import {
+    CustomerNotification,
+    fetchCustomerNotifications,
+    markAllCustomerNotificationsRead,
+} from "../../api/customerAccount";
 import { useAuth } from "../../context/AuthContext";
 import { useToast } from "../../context/ToastContext";
+import CustomerAccountShell from "../common/account/CustomerAccountShell";
 import Layout from "../layout/Layout";
 import { formatUtcDateTime } from "../../utils/dateTime";
 import "../../styles/CustomerNotificationsPage.scss";
-
-type CustomerNotification = {
-    id: number;
-    type: string;
-    title: string;
-    message: string;
-    link: string | null;
-    read_at: string | null;
-    created_at: string;
-    is_read: boolean;
-};
 
 const CustomerNotificationsPage = () => {
     const { userData } = useAuth();
@@ -28,8 +22,8 @@ const CustomerNotificationsPage = () => {
     const fetchNotifications = async () => {
         if (!uid) return;
         try {
-            const response = await axios.get(`/api/users/${uid}/notifications?limit=50`);
-            setNotifications(response.data.notifications || []);
+            const response = await fetchCustomerNotifications(uid, 50);
+            setNotifications(response.notifications);
         } catch {
             addToast("Notifications", "Unable to load notifications.");
         }
@@ -42,7 +36,7 @@ const CustomerNotificationsPage = () => {
     const markAllRead = async () => {
         if (!uid) return;
         try {
-            await axios.post(`/api/users/${uid}/notifications/read-all`);
+            await markAllCustomerNotificationsRead(uid);
             setNotifications((current) => current.map((item) => ({ ...item, is_read: true, read_at: item.read_at || new Date().toISOString() })));
         } catch {
             addToast("Notifications", "Unable to update notifications.");
@@ -56,14 +50,12 @@ const CustomerNotificationsPage = () => {
                 <meta name="description" content="Review customer account and order notifications." />
             </Helmet>
             <main className="customer-notifications">
-                <header className="customer-notifications__header">
-                    <div>
-                        <span>Account</span>
-                        <h1>Notifications</h1>
-                        <p>Order updates, checkout messages, and important account events.</p>
-                    </div>
-                    <button type="button" onClick={markAllRead}>Mark all read</button>
-                </header>
+                <CustomerAccountShell
+                    eyebrow="Account"
+                    title="Notifications"
+                    description="Order updates, checkout messages, and important account events."
+                    actions={<button type="button" onClick={markAllRead}>Mark all read</button>}
+                />
 
                 <section className="customer-notifications__list">
                     {notifications.length > 0 ? (

--- a/client/src/components/pages/OrderHistoryPage.tsx
+++ b/client/src/components/pages/OrderHistoryPage.tsx
@@ -1,46 +1,20 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { Helmet } from "react-helmet";
 import { useSearchParams } from "react-router-dom";
-import axios from "../../api/axios";
+import {
+    CustomerOrder,
+    CustomerOrderDetail,
+    addItemsToCustomerCart,
+    fetchCustomerOrderDetail,
+    fetchCustomerOrders,
+} from "../../api/customerAccount";
 import { useAuth } from "../../context/AuthContext";
 import { useToast } from "../../context/ToastContext";
 import Layout from "../layout/Layout";
+import CustomerAccountShell from "../common/account/CustomerAccountShell";
 import { CartIcon } from "../common/Icons";
 import "../../styles/OrderHistoryPage.scss";
 import { formatUtcDate, formatUtcDateTime } from "../../utils/dateTime";
-
-type Order = {
-    id: number;
-    date_added: string;
-    status: number;
-    total_price: number;
-    discount: number;
-    shipping_address: string;
-    payment_method?: "bank_transfer" | "cash";
-};
-
-type OrderItem = {
-    productId: number;
-    productName: string;
-    brand: string;
-    category: string;
-    price: number;
-    sale_price: number | null;
-    stock: number;
-    quantity: number;
-    totalPrice: number;
-};
-
-type OrderDetail = Order & {
-    items: OrderItem[];
-    timeline?: Array<{
-        id: number;
-        label: string;
-        note: string | null;
-        created_at: string | null;
-        status: number;
-    }>;
-};
 
 const getStatusLabel = (status: number) => {
     if (status === 1) return "Done";
@@ -48,7 +22,7 @@ const getStatusLabel = (status: number) => {
     return "Canceled";
 };
 
-const getPaymentLabel = (payment?: Order["payment_method"]) => {
+const getPaymentLabel = (payment?: CustomerOrder["payment_method"]) => {
     if (payment === "bank_transfer") return "Bank transfer";
     if (payment === "cash") return "Cash on delivery";
     return "Not recorded";
@@ -61,9 +35,9 @@ const OrderHistoryPage = () => {
     const [searchParams] = useSearchParams();
     const uid = userData?.id || "";
     const { addToast } = useToast();
-    const [orders, setOrders] = useState<Order[]>([]);
+    const [orders, setOrders] = useState<CustomerOrder[]>([]);
     const [selectedOrderId, setSelectedOrderId] = useState<number | null>(null);
-    const [orderDetail, setOrderDetail] = useState<OrderDetail | null>(null);
+    const [orderDetail, setOrderDetail] = useState<CustomerOrderDetail | null>(null);
     const [loadingDetail, setLoadingDetail] = useState(false);
 
     useEffect(() => {
@@ -71,10 +45,7 @@ const OrderHistoryPage = () => {
             if (!uid) return;
 
             try {
-                const response = await axios.get(`/api/orders/user/${uid}`);
-                if (response.status === 200) {
-                    setOrders(response.data.orders || []);
-                }
+                setOrders(await fetchCustomerOrders(uid));
             } catch {
                 addToast("Orders", "Unable to load order history.");
             }
@@ -92,10 +63,7 @@ const OrderHistoryPage = () => {
 
             try {
                 setLoadingDetail(true);
-                const response = await axios.get(`/api/orders/${selectedOrderId}`);
-                if (response.status === 200) {
-                    setOrderDetail(response.data.order);
-                }
+                setOrderDetail(await fetchCustomerOrderDetail(selectedOrderId));
             } catch {
                 addToast("Orders", "Unable to load order detail.");
             } finally {
@@ -129,15 +97,7 @@ const OrderHistoryPage = () => {
         }
 
         try {
-            await Promise.all(
-                availableItems.map((item) =>
-                    axios.post("/api/cart/", {
-                        uid,
-                        pid: item.productId,
-                        quantity: Math.min(item.quantity, item.stock),
-                    }),
-                ),
-            );
+            await addItemsToCustomerCart(uid, availableItems);
             addToast("Reorder", "Available items were added to your cart.");
         } catch {
             addToast("Reorder", "Unable to add the order items to your cart.");
@@ -151,13 +111,11 @@ const OrderHistoryPage = () => {
                 <meta name="description" content="Review previous orders and reorder available items." />
             </Helmet>
             <main className="order-history">
-                <header className="order-history__header">
-                    <div>
-                        <span>Orders</span>
-                        <h1>Order history</h1>
-                        <p>Track previous purchases, check payment details, and reorder available products.</p>
-                    </div>
-                </header>
+                <CustomerAccountShell
+                    eyebrow="Orders"
+                    title="Order history"
+                    description="Track previous purchases, check payment details, and reorder available products."
+                />
 
                 {orders.length === 0 ? (
                     <section className="order-history__empty">

--- a/client/src/routes/AppRoutes.tsx
+++ b/client/src/routes/AppRoutes.tsx
@@ -15,6 +15,7 @@ const ShopsPage = lazy(() => import("../components/pages/ShopsPage"));
 const NewsPage = lazy(() => import("../components/pages/NewsPage"));
 const SupportPage = lazy(() => import("../components/pages/SupportPage"));
 const CheckoutSuccessPage = lazy(() => import("../components/pages/CheckoutSuccessPage"));
+const CustomerAccountPage = lazy(() => import("../components/pages/CustomerAccountPage"));
 const OrderHistoryPage = lazy(() => import("../components/pages/OrderHistoryPage"));
 const AddressBookPage = lazy(() => import("../components/pages/AddressBookPage"));
 const CustomerNotificationsPage = lazy(() => import("../components/pages/CustomerNotificationsPage"));
@@ -29,6 +30,7 @@ const NoPage = lazy(() => import("../components/pages/NoPage"));
 
 const ProtectedCartPage = withSessionCheck(CartPage);
 const ProtectedCheckoutSuccessPage = withSessionCheck(CheckoutSuccessPage);
+const ProtectedCustomerAccountPage = withSessionCheck(CustomerAccountPage);
 const ProtectedOrderHistoryPage = withSessionCheck(OrderHistoryPage);
 const ProtectedAddressBookPage = withSessionCheck(AddressBookPage);
 const ProtectedCustomerNotificationsPage = withSessionCheck(CustomerNotificationsPage);
@@ -56,6 +58,7 @@ const AppRoutes = () => {
                 <Route path="/news" element={<NewsPage />} />
                 <Route path="/support" element={<SupportPage />} />
                 <Route path="/checkout-success" element={<ProtectedCheckoutSuccessPage />} />
+                <Route path="/account" element={<ProtectedCustomerAccountPage />} />
                 <Route path="/orders" element={<ProtectedOrderHistoryPage />} />
                 <Route path="/addresses" element={<ProtectedAddressBookPage />} />
                 <Route path="/notifications" element={<ProtectedCustomerNotificationsPage />} />

--- a/client/src/styles/AddressBookPage.scss
+++ b/client/src/styles/AddressBookPage.scss
@@ -4,27 +4,6 @@
     background: #f8fafc;
     overflow-x: hidden;
 
-    &__header {
-        margin-bottom: 1.5rem;
-
-        span {
-            color: #64748b;
-            font-size: 0.78rem;
-            font-weight: 900;
-            text-transform: uppercase;
-        }
-
-        h1 {
-            margin: 0.35rem 0;
-            color: #0f172a;
-        }
-
-        p {
-            margin: 0;
-            color: #64748b;
-        }
-    }
-
     &__layout {
         display: grid;
         grid-template-columns: minmax(280px, 0.8fr) minmax(0, 1.4fr);

--- a/client/src/styles/CustomerAccountPage.scss
+++ b/client/src/styles/CustomerAccountPage.scss
@@ -1,0 +1,258 @@
+.customer-account-page {
+    min-height: 100vh;
+    padding: 2.5rem 2rem 4rem;
+    background: #f8fafc;
+
+    &__loading,
+    &__hero,
+    &__panel,
+    &__actions a {
+        background: #fff;
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        box-shadow: 0 14px 28px rgba(15, 23, 42, 0.08);
+    }
+
+    &__loading,
+    &__hero,
+    &__panel {
+        max-width: 1180px;
+        margin: 0 auto;
+        border-radius: 18px;
+    }
+
+    &__loading {
+        padding: 1.5rem;
+        color: #475569;
+    }
+
+    &__hero {
+        display: grid;
+        grid-template-columns: minmax(0, 1.2fr) minmax(280px, 0.8fr);
+        gap: 1rem;
+        padding: 1.5rem;
+        margin-bottom: 1rem;
+    }
+
+    &__identity {
+        display: grid;
+        gap: 0.55rem;
+        min-width: 0;
+
+        h2 {
+            margin: 0;
+            color: #0f172a;
+            font-size: 2rem;
+        }
+
+        p,
+        small {
+            margin: 0;
+            color: #64748b;
+        }
+
+        &__badge {
+            width: fit-content;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.45rem;
+            border-radius: 999px;
+            background: #dbeafe;
+            color: #1d4ed8;
+            padding: 0.35rem 0.7rem;
+            font-size: 0.82rem;
+            font-weight: 900;
+        }
+    }
+
+    &__stats {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 0.75rem;
+
+        article {
+            border-radius: 16px;
+            background: #f8fafc;
+            padding: 1rem;
+            display: grid;
+            gap: 0.35rem;
+        }
+
+        span {
+            color: #64748b;
+            font-size: 0.8rem;
+            font-weight: 800;
+        }
+
+        strong {
+            color: #0f172a;
+            font-size: 1.7rem;
+        }
+    }
+
+    &__actions {
+        max-width: 1180px;
+        margin: 0 auto 1rem;
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 0.75rem;
+
+        a {
+            min-width: 0;
+            border-radius: 16px;
+            color: #0f172a;
+            padding: 1rem;
+            text-decoration: none;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.6rem;
+            font-weight: 900;
+        }
+    }
+
+    &__grid {
+        max-width: 1180px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 1rem;
+    }
+
+    &__panel {
+        padding: 1.2rem;
+        display: grid;
+        gap: 0.9rem;
+        min-width: 0;
+    }
+
+    &__panel__header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+
+        h3 {
+            margin: 0;
+            color: #0f172a;
+        }
+
+        a {
+            color: #0b5fff;
+            text-decoration: none;
+            font-weight: 900;
+        }
+    }
+
+    &__order-list,
+    &__notification-list {
+        display: grid;
+        gap: 0.75rem;
+
+        a {
+            border-radius: 14px;
+            background: #f8fafc;
+            padding: 0.95rem;
+            text-decoration: none;
+            color: inherit;
+            display: grid;
+            gap: 0.35rem;
+            min-width: 0;
+        }
+    }
+
+    &__order-list a {
+        grid-template-columns: minmax(0, 1fr) auto;
+        gap: 0.8rem;
+
+        > div {
+            display: grid;
+            gap: 0.2rem;
+            min-width: 0;
+        }
+
+        strong,
+        em {
+            color: #0f172a;
+            font-style: normal;
+        }
+
+        span,
+        small {
+            color: #64748b;
+        }
+    }
+
+    &__address {
+        display: grid;
+        gap: 0.45rem;
+
+        strong {
+            color: #0f172a;
+        }
+
+        p,
+        span,
+        small {
+            margin: 0;
+            color: #64748b;
+            overflow-wrap: anywhere;
+        }
+    }
+
+    &__notification-list a {
+        &.is-unread {
+            border: 1px solid #bfdbfe;
+            background: #eff6ff;
+        }
+
+        strong {
+            color: #0f172a;
+        }
+
+        span,
+        p {
+            margin: 0;
+            color: #64748b;
+        }
+    }
+
+    &__empty {
+        margin: 0;
+        color: #64748b;
+    }
+
+    @media (max-width: 980px) {
+        &__hero,
+        &__grid,
+        &__actions {
+            grid-template-columns: 1fr;
+        }
+
+        &__stats {
+            grid-template-columns: repeat(3, minmax(0, 1fr));
+        }
+    }
+
+    @media (max-width: 520px) {
+        padding: 1.25rem 0.9rem 3rem;
+
+        &__hero,
+        &__panel,
+        &__loading {
+            padding: 1rem;
+            border-radius: 14px;
+        }
+
+        &__stats {
+            grid-template-columns: 1fr;
+        }
+
+        &__actions a {
+            justify-content: flex-start;
+        }
+
+        &__order-list a {
+            grid-template-columns: 1fr;
+        }
+    }
+}

--- a/client/src/styles/CustomerAccountShell.scss
+++ b/client/src/styles/CustomerAccountShell.scss
@@ -1,0 +1,103 @@
+.customer-account-shell {
+    max-width: 1180px;
+    margin: 0 auto 1.25rem;
+
+    &__header {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 1rem;
+        margin-bottom: 1rem;
+
+        span {
+            color: #64748b;
+            font-size: 0.78rem;
+            font-weight: 900;
+            letter-spacing: 0.12em;
+            text-transform: uppercase;
+        }
+
+        h1 {
+            margin: 0.35rem 0 0.4rem;
+            color: #0f172a;
+            font-size: 2.4rem;
+        }
+
+        p {
+            margin: 0;
+            color: #64748b;
+            max-width: 44rem;
+        }
+    }
+
+    &__actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+
+        button,
+        a {
+            border: none;
+            border-radius: 12px;
+            background: #0b5fff;
+            color: #fff;
+            padding: 0.75rem 1rem;
+            font-weight: 900;
+            text-decoration: none;
+        }
+    }
+
+    &__nav {
+        display: flex;
+        gap: 0.75rem;
+        overflow-x: auto;
+        padding-bottom: 0.2rem;
+        scrollbar-width: thin;
+
+        a {
+            flex: 0 0 auto;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.45rem;
+            border: 1px solid #dbe4f0;
+            border-radius: 999px;
+            background: rgba(255, 255, 255, 0.9);
+            color: #334155;
+            padding: 0.72rem 0.95rem;
+            text-decoration: none;
+            font-weight: 800;
+            transition:
+                background-color 0.2s ease,
+                border-color 0.2s ease,
+                color 0.2s ease;
+
+            &.is-active {
+                background: #0b5fff;
+                border-color: #0b5fff;
+                color: #fff;
+            }
+        }
+    }
+
+    @media (max-width: 860px) {
+        &__header {
+            flex-direction: column;
+        }
+    }
+
+    @media (max-width: 520px) {
+        margin-bottom: 1rem;
+
+        &__header h1 {
+            font-size: 1.95rem;
+        }
+
+        &__nav {
+            gap: 0.55rem;
+
+            a {
+                padding: 0.68rem 0.85rem;
+            }
+        }
+    }
+}

--- a/client/src/styles/CustomerNotificationsPage.scss
+++ b/client/src/styles/CustomerNotificationsPage.scss
@@ -2,42 +2,11 @@
     min-height: 100vh;
     padding: 2.5rem 2rem 4rem;
     background: #f8fafc;
-
-    &__header {
-        display: flex;
-        justify-content: space-between;
-        gap: 1rem;
-        align-items: flex-start;
-        margin-bottom: 1.5rem;
-
-        span {
-            color: #64748b;
-            font-size: 0.78rem;
-            font-weight: 900;
-            text-transform: uppercase;
-        }
-
-        h1 {
-            margin: 0.35rem 0;
-            color: #0f172a;
-        }
-
-        p {
-            margin: 0;
-            color: #64748b;
-        }
-
-        button {
-            border: none;
-            border-radius: 12px;
-            background: #0b5fff;
-            color: #fff;
-            padding: 0.75rem 1rem;
-            font-weight: 900;
-        }
-    }
+    overflow-x: hidden;
 
     &__list {
+        max-width: 1180px;
+        margin: 0 auto;
         display: grid;
         gap: 1rem;
 
@@ -77,6 +46,7 @@
             p {
                 margin: 0;
                 color: #475569;
+                overflow-wrap: anywhere;
             }
 
             a {
@@ -91,9 +61,20 @@
         color: #64748b;
     }
 
-    @media (max-width: 720px) {
-        &__header {
+    @media (max-width: 520px) {
+        padding: 1.25rem 0.9rem 3rem;
+
+        &__list {
+            article,
+            .customer-notifications__empty {
+                border-radius: 12px;
+                padding: 0.9rem;
+            }
+        }
+
+        &__list article > div {
             flex-direction: column;
+            gap: 0.25rem;
         }
     }
 }

--- a/client/src/styles/OrderHistoryPage.scss
+++ b/client/src/styles/OrderHistoryPage.scss
@@ -2,29 +2,7 @@
     padding: 2.5rem 2rem 4rem;
     background: #f8fafc;
     min-height: 100vh;
-
-    &__header {
-        margin-bottom: 1.5rem;
-
-        span {
-            color: #64748b;
-            font-size: 0.78rem;
-            font-weight: 900;
-            letter-spacing: 0.12em;
-            text-transform: uppercase;
-        }
-
-        h1 {
-            margin: 0.35rem 0 0.4rem;
-            color: #0f172a;
-            font-size: 2.4rem;
-        }
-
-        p {
-            color: #64748b;
-            margin: 0;
-        }
-    }
+    overflow-x: hidden;
 
     &__empty,
     &__list,
@@ -36,10 +14,14 @@
     }
 
     &__empty {
+        max-width: 1180px;
+        margin: 0 auto;
         padding: 2rem;
     }
 
     &__layout {
+        max-width: 1180px;
+        margin: 0 auto;
         display: grid;
         grid-template-columns: minmax(260px, 0.75fr) minmax(0, 1.6fr);
         gap: 1.25rem;
@@ -50,6 +32,7 @@
         display: flex;
         flex-direction: column;
         overflow: hidden;
+        min-width: 0;
 
         button {
             border: none;
@@ -68,17 +51,20 @@
 
             strong {
                 color: #0f172a;
+                overflow-wrap: anywhere;
             }
 
             span,
             small {
                 color: #64748b;
+                overflow-wrap: anywhere;
             }
         }
     }
 
     &__detail {
         padding: 1.5rem;
+        min-width: 0;
     }
 
     &__detail__header {
@@ -91,6 +77,7 @@
         h2 {
             margin: 0.4rem 0 0.25rem;
             color: #0f172a;
+            overflow-wrap: anywhere;
         }
 
         p {
@@ -153,6 +140,7 @@
 
         strong {
             color: #0f172a;
+            overflow-wrap: anywhere;
         }
     }
 
@@ -197,14 +185,17 @@
             gap: 1rem;
             border-top: 1px solid #e5e7eb;
             padding-top: 0.75rem;
+            min-width: 0;
         }
 
         strong {
             color: #0f172a;
+            overflow-wrap: anywhere;
         }
 
         span {
             color: #64748b;
+            overflow-wrap: anywhere;
         }
     }
 
@@ -212,6 +203,32 @@
         &__layout,
         &__meta {
             grid-template-columns: 1fr;
+        }
+    }
+
+    @media (max-width: 520px) {
+        padding: 1.25rem 0.9rem 3rem;
+
+        &__detail,
+        &__empty {
+            padding: 1rem;
+        }
+
+        &__detail__header {
+            flex-direction: column;
+
+            button {
+                width: 100%;
+                justify-content: center;
+            }
+        }
+
+        &__timeline {
+            grid-template-columns: 1fr;
+        }
+
+        &__items > div {
+            flex-direction: column;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a new `/account` customer hub page with shared account navigation
- centralize customer account data fetching into a reusable client API helper
- refactor orders, addresses, and notifications pages onto the shared shell and tighten mobile layouts

## Verification
- `./client/node_modules/.bin/tsc.cmd -p client/tsconfig.json --noEmit`
- `corepack pnpm --filter client build`

## Notes
- existing customer routes `/orders`, `/addresses`, and `/notifications` remain intact
- backend APIs and response shapes were not changed
- `.gitignore` was left out because it was unrelated to this feature