### PR TITLE
feat(ci): add GitHub Actions promotion workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,80 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - main
+      - production
+  push:
+    branches:
+      - dev
+      - main
+      - production
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  server:
+    name: Server checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck server
+        run: pnpm --filter server typecheck
+
+      - name: Lint server
+        run: pnpm --filter server lint
+
+      - name: Build server
+        run: pnpm --filter server build
+
+  client:
+    name: Client checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint client
+        run: pnpm --filter client lint
+
+      - name: Test client
+        run: pnpm --filter client test -- --run
+
+      - name: Build client
+        run: pnpm --filter client build

--- a/.github/workflows/promote-dev-to-main.yml
+++ b/.github/workflows/promote-dev-to-main.yml
@@ -1,0 +1,73 @@
+name: Promote dev to main
+
+on:
+  workflow_run:
+    workflows:
+      - CI
+    branches:
+      - dev
+    types:
+      - completed
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: promote-dev-to-main
+  cancel-in-progress: false
+
+jobs:
+  open-promotion-pr:
+    name: Open dev to main PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+
+    steps:
+      - name: Check promotion diff
+        id: diff
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PR_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          ahead_by=$(gh api "repos/${GH_REPO}/compare/main...dev" --jq '.ahead_by')
+          echo "ahead_by=${ahead_by}" >> "$GITHUB_OUTPUT"
+
+          if [ "$ahead_by" = "0" ]; then
+            echo "No dev changes to promote."
+          fi
+
+      - name: Create or update promotion PR
+        if: steps.diff.outputs.ahead_by != '0'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PR_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          title="chore(release): promote dev to main"
+          body_file="$(mktemp)"
+          cat > "$body_file" <<'EOF'
+          ## Summary
+
+          Automated promotion PR from `dev` to `main` after CI passed on `dev`.
+
+          ## Verification
+
+          - Source workflow: CI
+          - Source branch: dev
+          - Target branch: main
+
+          ## Merge Policy
+
+          This PR is not auto-merged. Review and merge it manually after release validation.
+          EOF
+
+          existing_pr="$(gh pr list --base main --head dev --state open --json number --jq '.[0].number // empty')"
+
+          if [ -n "$existing_pr" ]; then
+            gh pr edit "$existing_pr" --title "$title" --body-file "$body_file"
+            echo "Updated existing PR #${existing_pr}."
+          else
+            gh pr create --base main --head dev --title "$title" --body-file "$body_file"
+          fi

--- a/.github/workflows/weekly-production-pr.yml
+++ b/.github/workflows/weekly-production-pr.yml
@@ -1,0 +1,68 @@
+name: Weekly production PR
+
+on:
+  schedule:
+    # Saturday 09:00 Asia/Ho_Chi_Minh.
+    - cron: "0 2 * * 6"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: weekly-production-pr
+  cancel-in-progress: false
+
+jobs:
+  open-production-pr:
+    name: Open main to production PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check production diff
+        id: diff
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PR_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          ahead_by=$(gh api "repos/${GH_REPO}/compare/production...main" --jq '.ahead_by')
+          echo "ahead_by=${ahead_by}" >> "$GITHUB_OUTPUT"
+
+          if [ "$ahead_by" = "0" ]; then
+            echo "No main changes to promote."
+          fi
+
+      - name: Create or update production PR
+        if: steps.diff.outputs.ahead_by != '0'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PR_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          title="chore(release): promote main to production"
+          body_file="$(mktemp)"
+          cat > "$body_file" <<'EOF'
+          ## Summary
+
+          Scheduled weekend production promotion PR from `main` to `production`.
+
+          ## Verification
+
+          - Source branch: main
+          - Target branch: production
+          - Schedule: Saturday 09:00 Asia/Ho_Chi_Minh
+
+          ## Merge Policy
+
+          This PR is not auto-merged. Review and merge it manually after production release validation.
+          EOF
+
+          existing_pr="$(gh pr list --base production --head main --state open --json number --jq '.[0].number // empty')"
+
+          if [ -n "$existing_pr" ]; then
+            gh pr edit "$existing_pr" --title "$title" --body-file "$body_file"
+            echo "Updated existing PR #${existing_pr}."
+          else
+            gh pr create --base production --head main --title "$title" --body-file "$body_file"
+          fi

--- a/client/src/features/orders/components/CheckoutPaymentPage.tsx
+++ b/client/src/features/orders/components/CheckoutPaymentPage.tsx
@@ -42,7 +42,6 @@ const CheckoutPaymentPage = ({
     cart,
     totalPrice,
     discount,
-    subtotal,
     validationIssues,
     onValidationRefresh,
 }: CheckoutPaymentProps) => {

--- a/client/src/utils/__tests__/images.test.ts
+++ b/client/src/utils/__tests__/images.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { getProductImageUrl, normalizeProductImageName } from "../images";
+
+describe("product image utilities", () => {
+    it("normalizes optional image filenames", () => {
+        expect(normalizeProductImageName("keyboard.jpg")).toBe("keyboard");
+        expect(normalizeProductImageName("KEYBOARD.JPG")).toBe("KEYBOARD");
+        expect(normalizeProductImageName("keyboard.png")).toBe("keyboard.png");
+        expect(normalizeProductImageName(null)).toBe("");
+    });
+
+    it("builds product image URLs from normalized names", () => {
+        expect(getProductImageUrl("keyboard.jpg")).toBe(
+            "https://2txtqipejre57csy.public.blob.vercel-storage.com/uploads/keyboard.jpg",
+        );
+        expect(getProductImageUrl("")).toBe("");
+    });
+});


### PR DESCRIPTION
## Summary

- Adds CI for pull requests and pushes targeting `dev`, `main`, and `production`.
- Adds a `dev` to `main` promotion workflow that creates or updates a PR after CI succeeds on `dev`.
- Adds a Saturday 09:00 Asia/Ho_Chi_Minh scheduled workflow that creates or updates a `main` to `production` PR.
- Adds a small Vitest utility smoke test so the client test command runs real test coverage.
- Removes an unused `subtotal` destructure that caused client lint to fail.

## Verification

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm --filter client test -- --run`
- `corepack pnpm --filter client lint`
- `corepack pnpm --filter client build`
- `corepack pnpm --filter server typecheck`
- `corepack pnpm --filter server lint`
- `corepack pnpm --filter server build`

## Notes

- CI uses Node `22.x` because the workspace is pinned to `pnpm@11.3.0`.
- Promotion workflows use `secrets.RELEASE_PR_TOKEN` when present and fall back to `secrets.GITHUB_TOKEN`.
- Repository settings still need Actions read/write workflow permissions and branch protection configured after this lands.

## Sources Used

- `AGENTS.md`
- GitHub Actions documentation via Context7
- Current package scripts and repository branch metadata